### PR TITLE
AuthenticationContext 새로고침시 데이터 유지되도록 수정

### DIFF
--- a/src/contexts/AuthenticationContext.tsx
+++ b/src/contexts/AuthenticationContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import {
   Authentication,
   AuthenticationContextType,
@@ -16,8 +16,14 @@ export const AuthenticationProvider = ({
   children,
 }: AuthenticationProviderProps) => {
   const [authentication, setAuthentication] = useState<Authentication | null>(
-    null,
+    sessionStorage.getItem("authentication")
+      ? JSON.parse(sessionStorage.getItem("authentication")!)
+      : null,
   );
+
+  useEffect(() => {
+    sessionStorage.setItem("authentication", JSON.stringify(authentication));
+  }, [authentication]);
 
   return (
     <AuthenticationContext.Provider


### PR DESCRIPTION
- `SessionStorage`에 authentication 정보 저장
- `AuthenticationContext`의 `authentication` state 초기값을 `SessionStorage`에서 불러와서 설정
- `authentication` state가 변경될 때 마다 `SessionStorage` 업데이트

Close #6